### PR TITLE
V0.0.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
 
             # Test
             - name: Test
-              run: export LIBGS="/usr/lib/x86_64-linux-gnu/libgs.so.9.55" && pnpm run test
+              run: export LIBGS="/usr/lib/x86_64-linux-gnu/libgs.so.10" && pnpm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vite-tex-loader",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "Vite loader for .tex files",
     "type": "module",
     "repository": {

--- a/readme.md
+++ b/readme.md
@@ -56,9 +56,10 @@ pnpm i -D vite-tex-loader
   ```
 - Import the `*.tex` file and use it (example JSX/TSX):
   ```tsx
-  import pdfUri from 'pdf.tex?pdf-uri';
-  import image1Uri from 'image1.tex?svg';
-  import { uri as image2Uri } from 'image2.tex?svg';
+  import pdfUri from 'pdf.tex?pdf-uri'; // Give the URI of the PDF in the public folder
+  import image1Uri from 'image1.tex?svg'; // Give the URI of the SVG in the public folder
+  import { uri as image2Uri } from 'image2.tex?svg'; // Give the URI of the SVG in the public folder
+  import { raw as image2Raw } from 'image2.tex?svg'; // Give the raw content of the SVG file
 
   export default function () {
       return (
@@ -66,6 +67,8 @@ pnpm i -D vite-tex-loader
               <a href={pdfUri}>PDF file</a>
               <img src={image1Uri} />
               <img src={image2Uri} />
+              {/* This loader doesn't create a React Node object, only raw text is provided */}
+              <div dangerouslySetInnerHTML={{ __html: image2Raw }} />
           </>
       );
   }

--- a/readme.md
+++ b/readme.md
@@ -56,9 +56,9 @@ pnpm i -D vite-tex-loader
   ```
 - Import the `*.tex` file and use it (example JSX/TSX):
   ```tsx
-  import pdfUri from `pdf.tex?pdf-uri`;
-  import image1Uri from `image1.tex?svg`;
-  import { uri as image2Uri } from `image2.tex?svg`;
+  import pdfUri from 'pdf.tex?pdf-uri';
+  import image1Uri from 'image1.tex?svg';
+  import { uri as image2Uri } from 'image2.tex?svg';
 
   export default function () {
       return (
@@ -77,6 +77,30 @@ Latex needs to generate temporary files which will be located in
 
 For example if you have a file `src/assets/pdf.tex`, the result PDF file will be
 `public/.auto-generated/src/assets/file.pdf`.
+
+There are several options on the loader that you can add to vite.config.js:
+
+- `LIBGS`: This can be set either as an option or as an environment variable. It
+  must contain the path to ghostscript library `libgs.so*` or `libgs.dylib*`
+- `svgLatexCliOptions`: Contains all CLI options you want to pass to `latex`
+  when generating the SVG file
+- `svgDvisvgmCliOptions`: Contains all CLI options you want to pass to `dvisvgm`
+  when generating the SVG file
+- `pdfPdfLatexCliOptions`: Contains all CLI options you want to pass to
+  `pdflatex` when generating the PDF file
+
+There is also a URI parameter that you can provide at each SVG file you want to
+generate:
+
+- `idPrefix`: The prefix to add before all auto generated ids in the SVG. This
+  is useful to avoid conflicts between SVGs in a single web page.
+
+This URI parameter is just a & separated key/value pair, identical to what web
+pages use. Here is an example on how to use this URI parameter:
+
+```tsx
+import svg from 'image2.tex?svg&idPrefix=test_';
+```
 
 # Tests and example
 

--- a/readme.md
+++ b/readme.md
@@ -121,12 +121,13 @@ the one in `./examples`:
 - The host must have `latex` installed, `pdflatex` to generate PDF files and
   `dvisvgm` to generate SVG files, and they must all be in the PATH environment
   variable.
-  - For the warning related to "PostScript specials", you must provide LIBGS
-    either as an environment variable or as an option in `vite.config.js` e.g.
+  - If you get the warning "processing of PostScript specials is disabled
+    (Ghostscript not found)", you must provide LIBGS either as an environment
+    variable or as an option in `vite.config.js` e.g.
     `texLoader({LIBGS: "/usr/local/share/ghostscript/9.55.0/lib/libgs.dylib.9.55"})`.
     The loader option has priority over the environment variable.
 
-    If both the environment variable and the options are not set,
+    If both the environment variable and the options are **not** set,
     `vite-tex-loader` will try to find the library on your system, but it's not
     guaranteed to succeed.
 - You have to create the type declaration for `*.tex` files yourself, it can't

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -21,6 +21,9 @@ export type viteTexLoaderOptions = {
      * Path to GhostScript lib (not executable)
      */
     LIBGS?: string;
+    svgLatexCliOptions?: string;
+    svgDvisvgmCliOptions?: string;
+    pdfPdflatexCliOptions?: string;
 };
 
 function hasStdout(e: unknown): e is { stdout: ArrayBuffer } {
@@ -112,6 +115,8 @@ function handleTexToSvg(
     filePath: string,
 ): string | undefined {
     const paths = getPaths(config, filePath, 'svg');
+    const latexCliOptions = options.svgLatexCliOptions ?? '';
+    const dvisvgmCliOptions = options.svgDvisvgmCliOptions ?? '';
     if (newVersion(paths.fileOriginPath, paths.fileDestPath)) {
         try {
             const libgsPath = findGhostScript(options.LIBGS);
@@ -119,8 +124,8 @@ function handleTexToSvg(
             const cmd = [
                 `mkdir -p "${paths.tmpDirPath}"`,
                 `mkdir -p "${paths.dirDestPath}"`,
-                `latex -output-directory="${paths.tmpDirPath}" -output-format=dvi "${paths.fileOriginPath}"`,
-                `dvisvgm -o "${paths.fileDestPath}" "${paths.tmpDirPath}/${paths.filenameWithoutTexExtension}.dvi"`,
+                `latex ${latexCliOptions} -output-directory="${paths.tmpDirPath}" -output-format=dvi "${paths.fileOriginPath}"`,
+                `dvisvgm ${dvisvgmCliOptions} -o "${paths.fileDestPath}" "${paths.tmpDirPath}/${paths.filenameWithoutTexExtension}.dvi"`,
             ].join(' && ');
             childProcess.execSync(`${libgs} ${cmd}`);
         } catch (e) {
@@ -145,6 +150,7 @@ function handleTexToPdf(
     filePath: string,
 ): string | undefined {
     const paths = getPaths(config, filePath, 'pdf');
+    const pdflatexCliOptions = options.pdfPdflatexCliOptions ?? '';
     if (newVersion(paths.fileOriginPath, paths.fileDestPath)) {
         try {
             const libgsPath = findGhostScript(options.LIBGS);
@@ -152,7 +158,7 @@ function handleTexToPdf(
             const cmd = [
                 `mkdir -p "${paths.tmpDirPath}"`,
                 `mkdir -p "${paths.dirDestPath}"`,
-                `pdflatex -output-directory="${paths.tmpDirPath}" "${paths.fileOriginPath}"`,
+                `pdflatex ${pdflatexCliOptions} -output-directory="${paths.tmpDirPath}" "${paths.fileOriginPath}"`,
                 `mv "${paths.tmpDirPath}/${paths.filenameWithoutTexExtension}.pdf" "${paths.fileDestPath}"`,
             ].join(' && ');
             childProcess.execSync(`${libgs} ${cmd}`);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -21,10 +21,51 @@ export type viteTexLoaderOptions = {
      * Path to GhostScript lib (not executable)
      */
     LIBGS?: string;
+    /**
+     * CLI options to pass to the `latex` executable
+     */
     svgLatexCliOptions?: string;
+    /**
+     * CLI options to pass to the `dvisvgm` executable
+     */
     svgDvisvgmCliOptions?: string;
+    /**
+     * CLI options to pass to the `pdflatex` executable
+     */
     pdfPdflatexCliOptions?: string;
 };
+type UriOptions = {
+    dvisvgmPrefix?: string;
+};
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+type viteTexLoaderOptionsMandatory =
+    & WithRequired<
+        viteTexLoaderOptions,
+        keyof viteTexLoaderOptions
+    >
+    & UriOptions;
+function convertOptionsToMandatory(
+    options: viteTexLoaderOptions,
+): viteTexLoaderOptionsMandatory {
+    return {
+        LIBGS: options.LIBGS ?? '',
+        svgLatexCliOptions: options.svgLatexCliOptions ?? '',
+        svgDvisvgmCliOptions: options.svgDvisvgmCliOptions ?? '',
+        pdfPdflatexCliOptions: options.pdfPdflatexCliOptions ?? '',
+    };
+}
+function readUriParams(params: string): Map<string, string> {
+    const map = new Map<string, string>();
+    const splittedParams = params.split('&')
+        .filter((s) => s.match(/.+=.+/) !== null)
+        .map((s) => s.split('='));
+    for (const [key, value] of splittedParams) {
+        if (key && value) {
+            map.set(key, value);
+        }
+    }
+    return map;
+}
 
 function hasStdout(e: unknown): e is { stdout: ArrayBuffer } {
     return (e instanceof Object || typeof e === 'object') && e !== null &&
@@ -89,8 +130,8 @@ function newVersion(fileOriginPath: string, fileDestPath: string) {
     return true;
 }
 
-function findGhostScript(libgs?: string) {
-    if (libgs !== undefined) {
+function findGhostScript(libgs: string) {
+    if (libgs.length !== 0) {
         return libgs;
     }
 
@@ -110,13 +151,11 @@ function findGhostScript(libgs?: string) {
 }
 
 function handleTexToSvg(
-    options: viteTexLoaderOptions,
+    options: viteTexLoaderOptionsMandatory,
     config: ReducedResolvedConfig,
     filePath: string,
 ): string | undefined {
     const paths = getPaths(config, filePath, 'svg');
-    const latexCliOptions = options.svgLatexCliOptions ?? '';
-    const dvisvgmCliOptions = options.svgDvisvgmCliOptions ?? '';
     if (newVersion(paths.fileOriginPath, paths.fileDestPath)) {
         try {
             const libgsPath = findGhostScript(options.LIBGS);
@@ -124,10 +163,32 @@ function handleTexToSvg(
             const cmd = [
                 `mkdir -p "${paths.tmpDirPath}"`,
                 `mkdir -p "${paths.dirDestPath}"`,
-                `latex ${latexCliOptions} -output-directory="${paths.tmpDirPath}" -output-format=dvi "${paths.fileOriginPath}"`,
-                `dvisvgm ${dvisvgmCliOptions} -o "${paths.fileDestPath}" "${paths.tmpDirPath}/${paths.filenameWithoutTexExtension}.dvi"`,
+                `latex ${options.svgLatexCliOptions} -output-directory="${paths.tmpDirPath}" -output-format=dvi "${paths.fileOriginPath}"`,
+                `dvisvgm ${options.svgDvisvgmCliOptions} -o "${paths.fileDestPath}" "${paths.tmpDirPath}/${paths.filenameWithoutTexExtension}.dvi"`,
             ].join(' && ');
             childProcess.execSync(`${libgs} ${cmd}`);
+
+            // Add a prefix to auto generated tag ids
+            // This prevents conflicts between svgs when used on a same web page
+            if (options.dvisvgmPrefix) {
+                let fileContent = fs.readFileSync(paths.fileDestPath)
+                    .toString();
+                const matches = [...(fileContent.matchAll(/id='([^']+)'/g))]
+                    .map(
+                        (m) => m[1],
+                    );
+                for (const m of matches) {
+                    fileContent = fileContent.replaceAll(
+                        `id='${m}'`,
+                        `id='${options.dvisvgmPrefix}${m}'`,
+                    );
+                    fileContent = fileContent.replaceAll(
+                        `xlink:href='#${m}'`,
+                        `xlink:href='#${options.dvisvgmPrefix}${m}'`,
+                    );
+                }
+                fs.writeFileSync(paths.fileDestPath, fileContent);
+            }
         } catch (e) {
             let stdout: string = '';
             if (hasStdout(e)) {
@@ -145,12 +206,11 @@ function handleTexToSvg(
 }
 
 function handleTexToPdf(
-    options: viteTexLoaderOptions,
+    options: viteTexLoaderOptionsMandatory,
     config: ReducedResolvedConfig,
     filePath: string,
 ): string | undefined {
     const paths = getPaths(config, filePath, 'pdf');
-    const pdflatexCliOptions = options.pdfPdflatexCliOptions ?? '';
     if (newVersion(paths.fileOriginPath, paths.fileDestPath)) {
         try {
             const libgsPath = findGhostScript(options.LIBGS);
@@ -158,7 +218,7 @@ function handleTexToPdf(
             const cmd = [
                 `mkdir -p "${paths.tmpDirPath}"`,
                 `mkdir -p "${paths.dirDestPath}"`,
-                `pdflatex ${pdflatexCliOptions} -output-directory="${paths.tmpDirPath}" "${paths.fileOriginPath}"`,
+                `pdflatex ${options.pdfPdflatexCliOptions} -output-directory="${paths.tmpDirPath}" "${paths.fileOriginPath}"`,
                 `mv "${paths.tmpDirPath}/${paths.filenameWithoutTexExtension}.pdf" "${paths.fileDestPath}"`,
             ].join(' && ');
             childProcess.execSync(`${libgs} ${cmd}`);
@@ -185,15 +245,28 @@ export function load(
     if (options.LIBGS === undefined && process.env.LIBGS) {
         options.LIBGS = process.env.LIBGS;
     }
+    const mandatoryOptions = convertOptionsToMandatory(options);
 
-    if (filePath.match(/.+\.tex\?svg$/)) {
-        return handleTexToSvg(options, config, filePath.replace(/\?svg$/, ''));
-    }
-    if (filePath.match(/.+\.tex\?pdf-uri$/)) {
-        return handleTexToPdf(
-            options,
+    let match = filePath.match(/(.+\.tex)\?svg(&.*)?$/);
+    if (match && match[1]) {
+        const map: Map<string, string> | null = match[2]
+            ? readUriParams(match[2])
+            : null;
+        if (map) {
+            mandatoryOptions.dvisvgmPrefix = map.get('idPrefix');
+        }
+        return handleTexToSvg(
+            mandatoryOptions,
             config,
-            filePath.replace(/\?pdf-uri$/, ''),
+            match[1],
+        );
+    }
+    match = filePath.match(/(.+\.tex)\?pdf-uri(&.*)?$/);
+    if (match && match[1]) {
+        return handleTexToPdf(
+            mandatoryOptions,
+            config,
+            match[1],
         );
     }
     // We don't support the file/module requested

--- a/tests/texToSvg.test.ts
+++ b/tests/texToSvg.test.ts
@@ -1,32 +1,66 @@
-import { expect, test } from '@jest/globals';
+import { beforeEach, describe, expect, test } from '@jest/globals';
 import fs from 'node:fs';
 import { load } from '../src/internal.ts';
 
-test('Converts triangle to SVG', () => {
-    const result = load(
-        {},
-        { root: './tests', publicDir: './tests/public' },
-        './examples/triangle.tex?svg',
-    );
-    expect(result).toEqual(
-        `export const uri = "/.auto-generated/./examples/triangle.svg"; export const raw = \`<?xml version='1.0' encoding='UTF-8'?>
+describe('SVG tests', () => {
+    beforeEach(() => {
+        fs.rmSync('./tests/.vite-tex-loader', {
+            recursive: true,
+            force: true,
+        });
+        fs.rmSync('./tests/public/.auto-generated', {
+            recursive: true,
+            force: true,
+        });
+    });
+
+    test('Converts triangle to SVG', () => {
+        const result = load(
+            {},
+            { root: './tests', publicDir: './tests/public' },
+            './examples/triangle.tex?svg',
+        );
+        expect(result).toEqual(
+            `export const uri = "/.auto-generated/./examples/triangle.svg"; export const raw = \`<?xml version='1.0' encoding='UTF-8'?>
 <svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='30.340256pt' height='30.340199pt' viewBox='-72.000181 -72.000175 30.340256 30.340199'>
 <g id='page1'>
 <path d='M-42.6562-42.656251H-71.003906V-71.0039Z' stroke='#f00' fill='none' stroke-width='1.99255' stroke-miterlimit='10'/>
 </g>
 </svg>\`; export default uri;`,
-    );
-    expect(fs.readdirSync('./tests/public/.auto-generated/./examples'))
-        .toContain(
-            'triangle.svg',
         );
-});
-test('Fails converting fail to SVG', () => {
-    expect(() =>
-        load(
+        expect(fs.readdirSync('./tests/public/.auto-generated/./examples'))
+            .toContain(
+                'triangle.svg',
+            );
+    });
+
+    test('Add prefix to SVG ids', () => {
+        const result = load(
             {},
             { root: './tests', publicDir: './tests/public' },
-            './tests/fail.tex?svg',
-        )
-    ).toThrow();
+            './examples/triangle.tex?svg&idPrefix=test_',
+        );
+        expect(result).toEqual(
+            `export const uri = "/.auto-generated/./examples/triangle.svg"; export const raw = \`<?xml version='1.0' encoding='UTF-8'?>
+<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='30.340256pt' height='30.340199pt' viewBox='-72.000181 -72.000175 30.340256 30.340199'>
+<g id='test_page1'>
+<path d='M-42.6562-42.656251H-71.003906V-71.0039Z' stroke='#f00' fill='none' stroke-width='1.99255' stroke-miterlimit='10'/>
+</g>
+</svg>\`; export default uri;`,
+        );
+        expect(fs.readdirSync('./tests/public/.auto-generated/./examples'))
+            .toContain(
+                'triangle.svg',
+            );
+    });
+
+    test('Fails converting fail to SVG', () => {
+        expect(() =>
+            load(
+                {},
+                { root: './tests', publicDir: './tests/public' },
+                './tests/fail.tex?svg',
+            )
+        ).toThrow();
+    });
 });


### PR DESCRIPTION
- Add options for `latex`, `pdflatex` and `dvisvgm`
- Add URI param to set a prefix on all class `id` in an svg (includes test)
- Update readme